### PR TITLE
Use KeyFuncWrapper instead of key_func.

### DIFF
--- a/kitten_options_utils.py
+++ b/kitten_options_utils.py
@@ -1,9 +1,17 @@
 from typing import Any, Callable, Iterable, Sequence, Tuple
 
-from kitty.conf.utils import KittensKeyDefinition, KeyFuncWrapper, parse_kittens_key
+from kitty.conf.utils import KittensKeyDefinition, parse_kittens_key
 
 FuncArgsType = Tuple[str, Sequence[Any]]
-func_with_args = KeyFuncWrapper[FuncArgsType]()
+
+try:
+    from kitty.conf.utils import KeyFuncWrapper
+    func_with_args = KeyFuncWrapper[FuncArgsType]()
+except ImportError:
+    from kitty.conf.utils import key_func
+    func_with_args, args_funcs = key_func()
+    func_with_args.args_funcs = args_funcs
+
 
 
 def parse_map(val: str) -> Iterable[KittensKeyDefinition]:

--- a/kitten_options_utils.py
+++ b/kitten_options_utils.py
@@ -1,13 +1,13 @@
 from typing import Any, Callable, Iterable, Sequence, Tuple
 
-from kitty.conf.utils import KittensKeyDefinition, key_func, parse_kittens_key
+from kitty.conf.utils import KittensKeyDefinition, KeyFuncWrapper, parse_kittens_key
 
-func_with_args, args_funcs = key_func()
 FuncArgsType = Tuple[str, Sequence[Any]]
+func_with_args = KeyFuncWrapper[FuncArgsType]()
 
 
 def parse_map(val: str) -> Iterable[KittensKeyDefinition]:
-    x = parse_kittens_key(val, args_funcs)
+    x = parse_kittens_key(val, func_with_args.args_funcs)
     if x is not None:
         yield x
 


### PR DESCRIPTION
Picking up from #12:

The current build fails to load any custom config because it cannot import key_func which was replaced by KeyFuncWrapper in kovidgoyal/kitty@a26f0419645ef24f6899076f8d326d51c5eaffa0.