### PR TITLE
Add a fix for kitty typing module changes in kitty version 0.42

### DIFF
--- a/grab.py
+++ b/grab.py
@@ -2,7 +2,11 @@ import os
 from typing import Any, Dict, List, Sequence
 
 from kittens.tui.handler import result_handler
-from kitty.typing import BossType
+
+try:
+    from kitty.typing import BossType
+except ImportError:
+    from kitty.typing_compat import BossType
 
 import _grab_ui
 


### PR DESCRIPTION
kitty.typing has been renamed to kitty.typing_compat in the latest version.