### PR TITLE
Replace kitty.typing with kitty.typing_compat

### DIFF
--- a/grab.py
+++ b/grab.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, Dict, List, Sequence
 
 from kittens.tui.handler import result_handler
-from kitty.typing import BossType
+from kitty.typing_compat import BossType
 
 import _grab_ui
 

--- a/grab.py
+++ b/grab.py
@@ -2,7 +2,12 @@ import os
 from typing import Any, Dict, List, Sequence
 
 from kittens.tui.handler import result_handler
-from kitty.typing_compat import BossType
+try:
+    # For kitty v0.42+
+    from kitty.typing_compat import BossType
+except ModuleNotFoundError:
+    # Fallback for older versions of kitty.
+    from kitty.typing import BossType
 
 import _grab_ui
 


### PR DESCRIPTION
In version 0.42 of kitty, the kitty.typing module was renamed to kitty.typing_compat. Changed the name in grab.py to restore kitty_grab's functioning.